### PR TITLE
Support for loading 1-bit and 32-bit bitmaps + compression type BI_BITFIELDS

### DIFF
--- a/bmp.h
+++ b/bmp.h
@@ -1152,6 +1152,7 @@ int bm_stricmp(const char *p, const char *q);
  *   by Darel Rex Finley.
  * * [Computer Graphics: Scan Line Polygon Fill Algorithm](https://hackernoon.com/computer-graphics-scan-line-polygon-fill-algorithm-3cb47283df6)
  *   by Alberto Scicali
+ * * [Count the consecutive zero bits (trailing) on the right in parallel](https://graphics.stanford.edu/~seander/bithacks.html#ZerosOnRightParallel)
  */
 
 #if defined(__cplusplus) || defined(c_plusplus)


### PR DESCRIPTION
Hello,
i was playing around with your bitmap library and added support for loading 1-bit 
and 32-bit bitmaps in the process. Also for compression type 3: BI_BITFIELDS because
its used on many 32-bit bmps.

I tested with a variety of formats from Jason Summers awesome collection at:
http://entropymine.com/jason/bmpsuite/bmpsuite/html/bmpsuite.html

Successfully loaded all the files my browser did:
-pal1.bmp
-pal1bg.bmp
-pal1p1.bmp
-pal1wb.bmp

-rgb32.bmp
-rgb32-7187.bmp
-rgb32-111110.bmp
-rgb32bf.bmp
-rgb32bfdef.bmp
-rgb32fakealpha.bmp *
-rgb32h52.bmp
-rgb32-xbgr.bmp
-rgba32.bmp *
-rgba32-61754.bmp *
-rgba32-81284.bmp *
-rgba32-1010102.bmp *

\* I currently load just the RGB components, without interpret the remaining bits of
32-bit bitmaps as alpha channel. Neither do i support the V4 / V5 headers which seem
to add alpha channel support. Altough i might add this another time.

Also, since the library keeps colors as R8G8B8A8, we loose some information when 
loading for example R11G11B10 because i have to downscale the channel to 8bit.

Furthermore, i compiled the library only from within VS2017 (MSVC++ 19.12.25830.2)
so I cannot say if other compilers will be happy with the code.

Last but not least, I tried to stick to your coding style and conventions, but i might 
have missed something.

Let me know if i need to fix or improve something in order to have the changes merged!

